### PR TITLE
Add parameter for door selection to open_door

### DIFF
--- a/UHPPOTE.php
+++ b/UHPPOTE.php
@@ -709,7 +709,7 @@ class uhppote {
                 break;
             case 'open_door':
                 $hexStr .= $this->sn;   // Add Serial Number
-                $hexStr .= '01';        // Add Door Number 01 02 03 04
+                $hexStr .= $addCardId['door'];        // Add Door Number 01 02 03 04
                 $this->debug("Open Door");
                 break;
             case 'set_recordIndex':


### PR DESCRIPTION
My first pull request, so be gentle. :-) This is simply to add the parameter for selecting the door to open with the open_door command. I'm sure it's simply an oversight that the door is hardcoded as '01'.